### PR TITLE
audio-annotator submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "audio-annotator"]
+	path = audio-annotator
+	url = https://github.com/cosmir/audio-annotator.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "audio-annotator"]
 	path = audio-annotator
 	url = https://github.com/cosmir/audio-annotator.git
+    branch = openmic-dev

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ See the [ReadMe](https://github.com/cosmir/open-mic/blob/master/backend_server/R
 If this is your first time checking out this repository, you'll need to pull in external
 dependencies by saying
 
-    ```bash
     git submodule update --init
-    ```
 
 after cloning the repository.

--- a/README.md
+++ b/README.md
@@ -53,3 +53,14 @@ Here are instructions for running the different parts of the system.
 ### Content Annotation System
 
 See the [ReadMe](https://github.com/cosmir/open-mic/blob/master/backend_server/README.md) for details on running the backend web server.
+
+### Audio annotator
+
+If this is your first time checking out this repository, you'll need to pull in external
+dependencies by saying
+
+    ```bash
+    git submodule update --init
+    ```
+
+after cloning the repository.


### PR DESCRIPTION
This PR imports our local fork of audio-annotator as a submodule.  It should supersede #32 .

Any changes that need to be made to the audio annotator code should be done in https://github.com/cosmir/audio-annotator and merged into the `openmic-dev` branch.

To use this, you need to `git submodule update --init`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cosmir/open-mic/35)
<!-- Reviewable:end -->
