### PR TITLE
Making the demo slightly easier to use

### DIFF
--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -52,11 +52,12 @@ def run(wport, sport):
         Server port number.
     """
     # Some sanity checks
-    assert os.path.isdir("docs") and os.path.isdir("backend_server"), \
-        "This script must be launched from OpenMic's root directory."
-    assert os.path.isdir("audio-annotator"), \
-        "Audio Annotator not found: please run:\n\t" \
-        "git submodule update --init"
+    if not os.path.isdir("docs") or not os.path.isdir("backend_server"):
+        raise EnvironmentError(
+            "This script must be launched from OpenMic's root directory.")
+    if not os.path.isdir("audio-annotator"):
+        raise EnvironmentError("Audio Annotator not found: please run:\n\t"
+                               "git submodule update --init")
 
     # Run the server
     cmd = "python {} --port {} --local {}".format(

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -12,7 +12,9 @@ caching behavior, which can cause the web app to use stale source files.
 """
 from __future__ import print_function
 
+import argparse
 from builtins import input
+import logging
 import os
 import requests
 from requests.packages.urllib3.util.retry import Retry
@@ -23,6 +25,8 @@ import sys
 
 HTTP_SERVER = {2: 'SimpleHTTPServer',
                3: 'http.server'}[sys.version_info.major]
+WEBAPP_PORT = 8000
+SERVER_PORT = 8080
 
 
 def kill(*proccesses):
@@ -30,36 +34,65 @@ def kill(*proccesses):
         os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
 
 
-def run():
-    server = subprocess.Popen(['python', 'backend_server/main.py', '--port',
-                               '8080', '--local', '--debug'],
-                              stdout=subprocess.PIPE, preexec_fn=os.setsid)
+def run(wport, sport):
+    # Run the server
+    cmd = "python {} --port {} --local {}".format(
+        os.path.join('backend_server', 'main.py'), sport, '--debug')
+    server = subprocess.Popen(cmd.split(" "), stdout=subprocess.PIPE,
+                              preexec_fn=os.setsid)
 
     # Test that the server is on; will raise an exception after enough attempts
     session = requests.Session()
     adapter = HTTPAdapter(max_retries=Retry(total=8, backoff_factor=0.1))
     session.mount('http://', adapter)
     try:
-        session.get('http://localhost:8080')
+        session.get('http://localhost:{}'.format(sport))
     except requests.exceptions.ConnectionError:
         kill(server)
         raise EnvironmentError(
             "Unable to confirm that the server started successfully.")
 
+    # Upload audio to the server
     fnames = ["267508__mickleness__3nf.ogg",
               "345515__furbyguy__strings-piano.ogg"]
     for fn in fnames:
-        fpath = os.path.abspath("./data/audio/{}".format(fn))
-        requests.post('http://localhost:8080/api/v0.1/audio',
+        fpath = os.path.abspath(os.path.join('data', 'audio', fn))
+        requests.post('http://localhost:{}/api/v0.1/audio'.format(sport),
                       files=dict(audio=open(fpath, 'rb')))
 
-    webapp = subprocess.Popen(['python', '-m', HTTP_SERVER],
+    # Run the webapp
+    webapp = subprocess.Popen(['python', '-m', HTTP_SERVER, str(wport)],
                               stdout=subprocess.PIPE, preexec_fn=os.setsid)
-
-    print("Now serving at: http://localhost:8000/docs/annotator.html")
-    input("Press return to exit.")
+    logging.info("Now serving at: http://localhost:{}"
+                 "/docs/annotator.html".format(wport))
+    try:
+        input("Press return to exit.\n")
+    except KeyboardInterrupt:
+        # Capturing Ctrl-C, to make sure we always shutdown the server
+        pass
+    logging.info("Shutting down server")
     kill(server, webapp)
 
 
 if __name__ == '__main__':
-    run()
+    parser = argparse.ArgumentParser(
+        description="Run a local demo of the server-annotator system.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("-p",
+                        dest="wport",
+                        default=WEBAPP_PORT,
+                        type=int,
+                        help="WebApp port number")
+    parser.add_argument("-sp",
+                        dest="sport",
+                        default=SERVER_PORT,
+                        type=int,
+                        help="Server port number")
+    args = parser.parse_args()
+
+    # Setup the logger
+    logging.basicConfig(format='%(asctime)s: %(levelname)s: %(message)s',
+                        level=logging.INFO)
+
+    # Call main process
+    run(args.wport, args.sport)

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -35,6 +35,13 @@ def kill(*proccesses):
 
 
 def run(wport, sport):
+    # Some sanity checks
+    assert os.path.isdir("docs") and os.path.isdir("backend_server"), \
+        "This script must be launched from OpenMic's root directory."
+    assert os.path.isdir("audio-annotator"), \
+        "Audio Annotator not found: please run:\n\t" \
+        "git submodule update --init"
+
     # Run the server
     cmd = "python {} --port {} --local {}".format(
         os.path.join('backend_server', 'main.py'), sport, '--debug')

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -30,11 +30,27 @@ SERVER_PORT = 8080
 
 
 def kill(*proccesses):
+    """Kills a list of processes.
+
+    Parameters
+    ----------
+    processes: list
+        List of process ids to be killed.
+    """
     for proc in proccesses:
         os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
 
 
 def run(wport, sport):
+    """Main process to run the demo.
+
+    Parameters
+    ----------
+    wport: int
+        Webapp port number.
+    sport: int
+        Server port number.
+    """
     # Some sanity checks
     assert os.path.isdir("docs") and os.path.isdir("backend_server"), \
         "This script must be launched from OpenMic's root directory."


### PR DESCRIPTION
I have added the following to the demo script:

* Argparse, parametrizing the two main ports (server and webapp).
* Allow for Ctrl-C to shutdown the server (it was really annoying to press Ctrl-C and still have the server running).
* Some checks so that it is easier for newcomers to know that:
  1. the script must be launched from the root folder
  2. the submodules are needed to run the demo
* Docstrings.